### PR TITLE
use correct framework

### DIFF
--- a/152_DotNet_Migration_From_4.8_to_8.0/Project.csproj
+++ b/152_DotNet_Migration_From_4.8_to_8.0/Project.csproj
@@ -34,7 +34,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 -   <TargetFramework>net48</TargetFramework>
-+   <TargetFramework>net80</TargetFramework>
++   <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>  
 
@@ -42,5 +42,5 @@
   <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 -   <TargetFramework>netstandard2.0</TargetFramework>
-+   <TargetFramework>net80</TargetFramework>
++   <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)